### PR TITLE
PERF: Optimize Allocations

### DIFF
--- a/SdpSerializer/Specifications/SdpVersion.cs
+++ b/SdpSerializer/Specifications/SdpVersion.cs
@@ -37,12 +37,7 @@ namespace Javor.SdpSerializer.Specifications
         /// <inheritdoc />
         public override string Encode()
         {
-            StringBuilder sb = new StringBuilder();
-            
-            sb.Append(SdpType);
-            sb.Append(Value);
-
-            return sb.ToString();
+            return $"{SdpType}{Value}";
         }
     }
 }

--- a/SdpSerializer/Specifications/SessionConnectionData.cs
+++ b/SdpSerializer/Specifications/SessionConnectionData.cs
@@ -51,22 +51,7 @@ namespace Javor.SdpSerializer.Specifications
         /// <inheritdoc />
         public override string Encode() 
         {
-            StringBuilder sb = new StringBuilder();
-
-            sb.Append(SdpType);
-            
-            // append nettype
-            sb.Append(NetType);
-            sb.Append(" ");
-
-            // append addrtype
-            sb.Append(AddressType);
-            sb.Append(" ");
-
-            // append connection address
-            sb.Append(ConnectionAddress);
-
-            return sb.ToString();
+            return $"{SdpType}{NetType} {AddressType} {ConnectionAddress}";
         }
     }
 }

--- a/SdpSerializer/Specifications/SessionName.cs
+++ b/SdpSerializer/Specifications/SessionName.cs
@@ -37,12 +37,7 @@ namespace Javor.SdpSerializer.Specifications
         /// <inheritdoc />
         public override string Encode()
         {
-            StringBuilder sb = new StringBuilder();
-            
-            sb.Append(SdpType);
-            sb.Append(Value);
-
-            return sb.ToString();
+            return $"{SdpType}{Value}";
         }
     }
 }

--- a/SdpSerializer/Specifications/SessionOrigin.cs
+++ b/SdpSerializer/Specifications/SessionOrigin.cs
@@ -64,29 +64,7 @@ namespace Javor.SdpSerializer.Specifications
         /// <inheritdoc />
         public override string Encode()
         {
-            string space = " ";
-            StringBuilder sb = new StringBuilder();
-            
-            sb.Append(SdpType);
-            
-            sb.Append(Username);
-            sb.Append(space);
-            
-            sb.Append(SessionId);
-            sb.Append(space); 
-            
-            sb.Append(SessionVersion);
-            sb.Append(space);
-            
-            sb.Append(NetType);
-            sb.Append(space);
-            
-            sb.Append(AddressType);
-            sb.Append(space);
-            
-            sb.Append(UnicastAddress);
-
-            return sb.ToString();
+            return $"{SdpType}{Username} {SessionId} {SessionVersion} {NetType} {AddressType} {UnicastAddress}";
         }
     }
 }

--- a/SdpSerializer/Specifications/SessionTiming.cs
+++ b/SdpSerializer/Specifications/SessionTiming.cs
@@ -44,14 +44,7 @@ namespace Javor.SdpSerializer.Specifications
         /// <inheritdoc />
         public override string Encode()
         {
-            StringBuilder sb = new StringBuilder();
-            
-            sb.Append(SdpType);
-            sb.Append(StartTime.ToString());
-            sb.Append(":");
-            sb.Append(StopTime.ToString());
-
-            return sb.ToString();
+            return $"{SdpType}{StartTime.ToString()}:{StopTime.ToString()}";
         }
     }
 }

--- a/SdpSeriallizer.Benchmarks/BenchmarkSettings.cs
+++ b/SdpSeriallizer.Benchmarks/BenchmarkSettings.cs
@@ -6,6 +6,7 @@ using Javor.SdpSerializer.Specifications;
 
 namespace SdpSeriallizer.Benchmarks
 {
+    [MemoryDiagnoser]
     public class BenchmarkSettings
     {
         public SessionDescription TestData { get; }


### PR DESCRIPTION
Hi @Jacfal, I've tried to make some performance optimizations to this repo. Following are the benchmark results before and after the changes:

**Benchmarks before changes:**
               Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
--------------------- |---------:|----------:|----------:|-------:|----------:|
 SdpEncodingBenchmark | 1.777 us | 0.0354 us | 0.0690 us | 0.3548 |    2.2 KB |

**Benchmarks after changes:**
               Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
--------------------- |---------:|----------:|----------:|-------:|----------:|
 SdpEncodingBenchmark | 1.596 us | 0.0266 us | 0.0249 us | 0.2480 |   1.55 KB |

As you can see the allocations have gone down. I've also made sure that all the unit tests pass following these changes as well. Could you please confirm whether or not you think my changes are valid?

Thank you!

